### PR TITLE
[add] get pixel's 3d vector

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ CC=				cc
 CFLAGS=			-Wall -Wextra -Werror -g
 NAME=			miniRT
 
-FILES=			color double error init_data main parse_capital parse_small parse parse_vector draw_all draw_img vector_cal1 vector_cal2
+FILES=			color double error init_data main parse_capital parse_small parse parse_vector draw_all draw_img vector_cal1 vector_cal2 draw_obj
 SRCS=			$(addsuffix .c, $(addprefix ./src/, $(FILES)))
 OBJS=			$(SRCS:.c=.o)
 SRCS_BONUS=		$(EMPTY)

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ To execute miniRT, you need formatted file with `.rt` expansion.
 **2024.02.17** 규칙 정하기 (커밋 메세지, 풀 리퀘스트)  
 **2024.02.20** parsing 구현 완료, 이론 공부 시작  
 **2024.02.25** mlx 기본 세팅 완료  
+**2024.02.26** 각 픽셀에 대한 벡터 구하기 완료, 도형 따로 구현 시작  
 
 # [Rules]
 ## commit message

--- a/include/draw.h
+++ b/include/draw.h
@@ -6,7 +6,7 @@
 /*   By: jaejilee <jaejilee@student.42seoul.kr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/25 10:57:20 by jaejilee          #+#    #+#             */
-/*   Updated: 2024/02/25 11:37:45 by jaejilee         ###   ########.fr       */
+/*   Updated: 2024/02/26 13:35:23 by jaejilee         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,6 +18,9 @@
 # define ON_DESTROY		17
 # define ON_KEYBOARD	2
 # define KB_ESC			53
+
+# define SCREEN_W		800
+# define SCREEN_H		800
 
 typedef struct s_mlx
 {
@@ -32,5 +35,9 @@ typedef struct s_mlx
 
 void	my_mlx_pixel_put(t_mlx *data, int x, int y, int color);
 void	draw_all(t_info info);
+void	make_img(t_mlx *data, t_info info);
+void	check_sphere(t_color *rgb, double *distance, t_vector v, t_info info);
+void	check_plane(t_color *rgb, double *distance, t_vector v, t_info info);
+void	check_cylinder(t_color *rgb, double *distance, t_vector v, t_info info);
 
 #endif

--- a/include/vector.h
+++ b/include/vector.h
@@ -6,7 +6,7 @@
 /*   By: jaejilee <jaejilee@student.42seoul.kr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/17 16:18:28 by jaejilee          #+#    #+#             */
-/*   Updated: 2024/02/25 15:53:10 by jaejilee         ###   ########.fr       */
+/*   Updated: 2024/02/26 14:46:37 by jaejilee         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -29,5 +29,6 @@ t_vector	*v_add(t_vector v1, t_vector v2);
 t_vector	*v_sub(t_vector v1, t_vector v2);
 double		*solve_quadratic(double a, double b, double c);
 t_point		*get_near_p(t_point cam, t_vector v, double *t);
+void		v_normalize(t_vector *v);
 
 #endif

--- a/src/draw_all.c
+++ b/src/draw_all.c
@@ -6,7 +6,7 @@
 /*   By: jaejilee <jaejilee@student.42seoul.kr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/25 10:31:44 by jaejilee          #+#    #+#             */
-/*   Updated: 2024/02/25 11:42:16 by jaejilee         ###   ########.fr       */
+/*   Updated: 2024/02/26 13:33:58 by jaejilee         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,8 +24,7 @@ void	draw_all(t_info info)
 	t_mlx	data;
 
 	init_mlx(&data);
-	// make_img();
-	(void)info;
+	make_img(&data, info);
 	mlx_put_image_to_window(data.mlx, data.win, data.img, 0, 0);
 	mlx_hook(data.win, ON_DESTROY, 0, close_exit, &data);
 	mlx_hook(data.win, ON_KEYBOARD, 0, key_hook, &data);
@@ -35,8 +34,8 @@ void	draw_all(t_info info)
 static void	init_mlx(t_mlx *data)
 {
 	data->mlx = mlx_init();
-	data->win = mlx_new_window(data->mlx, 800, 800, "miniRT");
-	data->img = mlx_new_image(data->mlx, 800, 800);
+	data->win = mlx_new_window(data->mlx, SCREEN_W, SCREEN_H, "miniRT");
+	data->img = mlx_new_image(data->mlx, SCREEN_W, SCREEN_H);
 	data->addr = mlx_get_data_addr(data->img, &data->bpp, \
 					&data->line_length, &data->endian);
 }

--- a/src/draw_img.c
+++ b/src/draw_img.c
@@ -6,11 +6,20 @@
 /*   By: jaejilee <jaejilee@student.42seoul.kr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/25 11:21:20 by jaejilee          #+#    #+#             */
-/*   Updated: 2024/02/25 11:23:10 by jaejilee         ###   ########.fr       */
+/*   Updated: 2024/02/26 15:25:46 by jaejilee         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "draw.h"
+#include "vector.h"
+#include "argument.h"
+#include "libft.h"
+#include <math.h>
+#include <stdio.h>
+
+static t_vector	*get_3d_vector(int x, int y, t_info info);
+static void		law_rodrigues(t_vector *res, t_vector cw, \
+							t_vector normal, t_vector ndc_t);
 
 void	my_mlx_pixel_put(t_mlx *data, int x, int y, int color)
 {
@@ -18,4 +27,66 @@ void	my_mlx_pixel_put(t_mlx *data, int x, int y, int color)
 
 	dst = data->addr + (y * data->line_length + x * (data->bpp / 8));
 	*(unsigned int *)dst = color;
+}
+
+void	make_img(t_mlx *data, t_info info)
+{
+	int			x;
+	int			y;
+	t_color		rgb;
+	double		disance;
+	t_vector	*v;
+
+	x = 0;
+	while (x < SCREEN_W)
+	{
+		y = 0;
+		while (y < SCREEN_H)
+		{
+			v = get_3d_vector(x, y, info);
+			printf("vector = (%f, %f, %f)\n", v->x, v->y, v->z);
+			check_sphere(&rgb, &disance, *v, info);
+			check_plane(&rgb, &disance, *v, info);
+			check_cylinder(&rgb, &disance, *v, info);
+			my_mlx_pixel_put(data, x, y, 0xFFFFFF);
+			free(v);
+			y++;
+		}
+		x++;
+	}
+	disance = 0;
+}
+
+static t_vector	*get_3d_vector(int x, int y, t_info info)
+{
+	t_vector	ndc_t;
+	t_vector	*res;
+	t_vector	*normal;
+
+	ndc_t.x = x - SCREEN_W / 2;
+	ndc_t.y = y - SCREEN_H / 2;
+	ndc_t.z = (SCREEN_W / 2) / tan(M_PI / 180 * (info.camera->fov / 2));
+	res = (t_vector *)ft_calloc(1, sizeof(t_vector));
+	normal = v_outer_product(ndc_t, info.camera->way);
+	v_normalize(normal);
+	law_rodrigues(res, info.camera->way, *normal, ndc_t);
+	free(normal);
+	return (res);
+}
+
+static void	law_rodrigues(t_vector *res, t_vector cw, \
+							t_vector normal, t_vector ndc_t)
+{
+	t_vector	*temp;
+	double		cos_th;
+	double		sin_th;
+
+	cos_th = v_inner_product(ndc_t, cw) \
+				/ (v_size(ndc_t) * v_size(cw));
+	sin_th = sqrt(1 - pow(cos_th, 2));
+	temp = v_outer_product(normal, cw);
+	res->x = cos_th * cw.x + sin_th * temp->x;
+	res->y = cos_th * cw.y + sin_th * temp->y;
+	res->z = cos_th * cw.z + sin_th * temp->z;
+	free(temp);
 }

--- a/src/draw_obj.c
+++ b/src/draw_obj.c
@@ -1,0 +1,39 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   draw_obj.c                                         :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: jaejilee <jaejilee@student.42seoul.kr>     +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/02/26 11:31:28 by jaejilee          #+#    #+#             */
+/*   Updated: 2024/02/26 15:03:34 by jaejilee         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "argument.h"
+#include "draw.h"
+#include <math.h>
+
+void	check_sphere(t_color *rgb, double *distance, t_vector v, t_info info)
+{
+	(void)rgb;
+	(void)distance;
+	(void)v;
+	(void)info;
+}
+
+void	check_plane(t_color *rgb, double *distance, t_vector v, t_info info)
+{
+	(void)rgb;
+	(void)distance;
+	(void)v;
+	(void)info;
+}
+
+void	check_cylinder(t_color *rgb, double *distance, t_vector v, t_info info)
+{
+	(void)rgb;
+	(void)distance;
+	(void)v;
+	(void)info;
+}

--- a/src/parse_capital.c
+++ b/src/parse_capital.c
@@ -6,7 +6,7 @@
 /*   By: jaejilee <jaejilee@student.42seoul.kr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/19 13:32:02 by jaejilee          #+#    #+#             */
-/*   Updated: 2024/02/25 12:51:45 by jaejilee         ###   ########.fr       */
+/*   Updated: 2024/02/26 15:24:18 by jaejilee         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,7 +24,8 @@ int	read_cam(t_info *info, char **all_info)
 		|| is_vector(all_info[1], &(res->loc)) == FALSE)
 		return (fail_free(res));
 	if (all_info[2] == NULL \
-		|| is_vector(all_info[2], &(res->way)) == FALSE)
+		|| is_vector(all_info[2], &(res->way)) == FALSE \
+		|| (res->way.x == 0 && res->way.y == 0 && res->way.z == 0))
 		return (fail_free(res));
 	if (all_info[3] == NULL \
 		|| is_unsigned_double(all_info[3], &(res->fov)) == FALSE \

--- a/src/vector_cal2.c
+++ b/src/vector_cal2.c
@@ -6,7 +6,7 @@
 /*   By: jaejilee <jaejilee@student.42seoul.kr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/25 13:54:45 by jaejilee          #+#    #+#             */
-/*   Updated: 2024/02/25 15:54:01 by jaejilee         ###   ########.fr       */
+/*   Updated: 2024/02/26 14:45:53 by jaejilee         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -57,4 +57,14 @@ double	*solve_quadratic(double a, double b, double c)
 		res[1] = (-1 * b + sqrt(pow(b, 2) - 4 * a * c)) / (2 * a);
 	}
 	return (res);
+}
+
+void	v_normalize(t_vector *v)
+{
+	double	size;
+
+	size = v_size(*v);
+	v->x /= size;
+	v->y /= size;
+	v->z /= size;
 }


### PR DESCRIPTION
# 픽셀 벡터 구하기
로드리게스 회전 법칙을 응용해서 mlx의 각 픽셀이 3d 카메라 좌표계에서 어떤 벡터를 갖는지 구하는 기능을 구현했습니다.
( 나중에 printf 빼줘야함)

# 파싱 예외처리
카메라의 방향벡터가 0벡터로 들어왔을 때 NaN 문제가 생기는 것을 확인하여 예외처리 했습니다.

# README
스케쥴 업데이트 했습니다.