### PR TITLE
[mod] fix cone long distance specular case

### DIFF
--- a/src/draw_cone.c
+++ b/src/draw_cone.c
@@ -6,7 +6,7 @@
 /*   By: dongyeuk <dongyeuk@student.42seoul.kr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/19 13:10:36 by dongyeuk          #+#    #+#             */
-/*   Updated: 2024/03/31 15:42:45 by dongyeuk         ###   ########.fr       */
+/*   Updated: 2024/03/31 20:49:29 by dongyeuk         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -81,21 +81,21 @@ static void	co_apply_rgb_bottom(t_final_c *rgb, t_point p, \
 {
 	t_light		*l;
 	t_obj_plane	pl_bottom;
+	t_vector	vec_light;
 	double		cos_th;
 
 	pl_bottom.color = co->color;
-	if (v_inner_product(p_get_vector(co->loc, p), co->normal) > 0)
-		pl_bottom.loc = v_add(co->loc, v_multiply(co->normal, co->height / 2));
-	else
-		pl_bottom.loc = v_sub(co->loc, v_multiply(co->normal, co->height / 2));
 	pl_bottom.normal = co->normal;
 	pl_bottom.temp_normal = co->normal;
 	rgb->color = co->color;
 	apply_ambient(rgb, info.amb);
 	l = info.lights;
+	vec_light = p_get_vector(l->loc, p);
+	if (p_is_in_co(l->loc, co) == 1)
+		vec_light = p_get_vector(p, l->loc);
 	while (l != NULL)
 	{
-		cos_th = v_get_cos(p_get_vector(p, l->loc), pl_bottom.temp_normal);
+		cos_th = v_get_cos(vec_light, pl_bottom.temp_normal);
 		if (p_is_in_co(l->loc, co) * is_in_co(co) == 1 && cos_th > 0 && \
 				check_obstacles(l->loc, p, info, (void *)co) == OBS_NOT_EXIST)
 		{

--- a/src/get_obj_normal.c
+++ b/src/get_obj_normal.c
@@ -6,7 +6,7 @@
 /*   By: dongyeuk <dongyeuk@student.42seoul.kr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/13 21:23:34 by dongyeuk          #+#    #+#             */
-/*   Updated: 2024/03/29 20:37:59 by dongyeuk         ###   ########.fr       */
+/*   Updated: 2024/03/31 20:26:50 by dongyeuk         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -63,7 +63,7 @@ t_vector	get_cone_normal(t_obj_cone *co, t_point p)
 		temp = 1 - pow(v_inner_product(co->loc, co->normal) / \
 				v_size(co->loc), 2);
 		temp = pow(temp * v_size(co->loc), 2) - \
-				pow((1 + v_inner_product(co->loc, co->normal) / \
+				pow((1 - v_inner_product(co->loc, co->normal) / \
 				co->height) * co->diameter / 2, 2);
 		if (get_sign(temp) == -1)
 			res_normal = v_multiply(res_normal, (-1));


### PR DESCRIPTION
- 원뿔 밑면 출력 대상 점에서 light로 가는 벡터 구하는 연산 수정
- 원뿔 옆면 공식 부호 틀린 부분 수정
확인 부탁합니다~
원기둥 점 찍히는건 확인했는데
NaN으로 계산되는 부분이 있어서 계산 식 따라가보니까 0으로 나누는 케이스 있어서 고쳐볼라 했는데 결국 못 고침..
내일 얘기해주겠음~!